### PR TITLE
🔨 Move env vars to app start script

### DIFF
--- a/powershell-universal/Dockerfile
+++ b/powershell-universal/Dockerfile
@@ -45,8 +45,6 @@ RUN apt-get update \
     && rm /tmp/universal.zip \
     && chmod +x ./home/Universal/Universal.Server
 
-
-
 # Labels
 LABEL \
     io.hass.name="PowerShell Universal" \
@@ -66,13 +64,3 @@ LABEL \
     org.opencontainers.image.created=${BUILD_DATE} \
     org.opencontainers.image.revision=${BUILD_REF} \
     org.opencontainers.image.version=${BUILD_VERSION}
-
-#Environment Variables 
-ENV Data__RepositoryPath /share/powershell-universal/Repository
-ENV Data__ConnectionString /share/powershell-universal/database.db
-ENV UniversalDashboard__AssetsFolder /share/powershell-universal/UniversalDashboard 
-ENV Logging__Path /share/powershell-universal/logs/log.txt
-ENV POWERSHELL_TELEMETRY_OPTOUT 1
-
-#EXPOSE 5000
-#ENTRYPOINT ["./home/Universal/Universal.Server"]

--- a/powershell-universal/rootfs/etc/services.d/universal/run
+++ b/powershell-universal/rootfs/etc/services.d/universal/run
@@ -7,4 +7,10 @@
 
 bashio::log.info "Starting PowerShell Universal ..."
 
+export Data__RepositoryPath=/share/powershell-universal/Repository
+export Data__ConnectionString=/share/powershell-universal/database.db
+export UniversalDashboard__AssetsFolder=/share/powershell-universal/UniversalDashboard 
+export Logging__Path=/share/powershell-universal/logs/log.txt
+export POWERSHELL_TELEMETRY_OPTOUT=1
+
 exec /home/Universal/Universal.Server


### PR DESCRIPTION
Move the environment variables from the Dockerfile, to the application startup script via exports.

This should give you more flexibility if you need to change them at runtime, rather than having to overwrite.